### PR TITLE
Fix: Deprecation Warnings

### DIFF
--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -24,7 +24,11 @@ from homeassistant.helpers.update_coordinator import (
 
 from homeassistant.components import recorder
 from homeassistant.components.recorder import statistics
-from homeassistant.components.recorder.models import StatisticData, StatisticMetaData
+from homeassistant.components.recorder.models import (
+    StatisticData,
+    StatisticMeanType,
+    StatisticMetaData,
+)
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfEnergy
@@ -241,7 +245,7 @@ class HistoricalSensorMixin(PollUpdateMixin, HistoricalSensor, SensorEntity):
     def get_statistic_metadata(self) -> StatisticMetaData:
         meta = super().get_statistic_metadata()
         meta["has_sum"] = True
-        meta["has_mean"] = True
+        meta["mean_type"] = StatisticMeanType.ARITHMETIC
 
         return meta
 
@@ -351,6 +355,7 @@ class Usage(PollUpdateMixin, HistoricalSensor, SensorEntity):
     def get_statistic_metadata(self) -> StatisticMetaData:
         meta = super().get_statistic_metadata()
         meta["has_sum"] = True
+        meta["mean_type"] = StatisticMeanType.NONE
 
         return meta
 

--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -34,6 +34,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfEnergy
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dtutil
+from homeassistant.util.unit_conversion import EnergyConverter
 
 from homeassistant_historical_sensor import (
     HistoricalSensor,
@@ -246,6 +247,7 @@ class HistoricalSensorMixin(PollUpdateMixin, HistoricalSensor, SensorEntity):
         meta = super().get_statistic_metadata()
         meta["has_sum"] = True
         meta["mean_type"] = StatisticMeanType.ARITHMETIC
+        meta["unit_class"] = None
 
         return meta
 
@@ -356,6 +358,7 @@ class Usage(PollUpdateMixin, HistoricalSensor, SensorEntity):
         meta = super().get_statistic_metadata()
         meta["has_sum"] = True
         meta["mean_type"] = StatisticMeanType.NONE
+        meta["unit_class"] = EnergyConverter.UNIT_CLASS
 
         return meta
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Changed from `meta["mean_type"]` to using the new `homeassistant.components.recorder.models.StatisticMeanType`
- Added `meta["unit_class"] = None` to `get_statistic_metadata()` methods, because it is mandatory.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The usage of `unit_class` and `mean_type` has changed as explained [here](https://developers.home-assistant.io/blog/2025/10/16/recorder-statistics-api-changes). Also, I was getting the warnings below. Note that row numbers may not perfectly line up as I was moving things around as I was trying to fix this
```
2025-11-17 09:39:55.009 WARNING (MainThread) [homeassistant.helpers.frame] Detected that custom integration 'hildebrandglow_dcc' doesn't specify mean_type when calling async_import_statistics at custom_components/hildebrandglow_dcc/sensor.py, line 303: await super().async_added_to_hass(). This will stop working in Home Assistant 2026.11, please create a bug report at https://github.com/HandyHat/ha-hildebrandglow-dcc/issues
2025-11-17 09:39:55.373 WARNING (MainThread) [homeassistant.helpers.frame] Detected that custom integration 'hildebrandglow_dcc' doesn't specify mean_type when calling async_import_statistics at custom_components/hildebrandglow_dcc/sensor.py, line 410: await super().async_added_to_hass(). This will stop working in Home Assistant 2026.11, please create a bug report at https://github.com/HandyHat/ha-hildebrandglow-dcc/issues
2025-11-17 09:52:46.518 WARNING (MainThread) [homeassistant.helpers.frame] Detected that custom integration 'hildebrandglow_dcc' doesn't specify unit_class when calling async_import_statistics at custom_components/hildebrandglow_dcc/sensor.py, line 416: await super().async_added_to_hass(). This will stop working in Home Assistant 2026.11, please create a bug report at https://github.com/HandyHat/ha-hildebrandglow-dcc/issues
2025-11-17 10:08:30.366 WARNING (MainThread) [homeassistant.helpers.frame] Detected that custom integration 'hildebrandglow_dcc' doesn't specify unit_class when calling async_import_statistics at custom_components/hildebrandglow_dcc/sensor.py, line 307: await super().async_added_to_hass(). This will stop working in Home Assistant 2026.11, please create a bug report at https://github.com/HandyHat/ha-hildebrandglow-dcc/issues
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've been running this version for a while. I'm getting no errors or warnings and the sensor data is being populated as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

@root0x I've made all the changes like for like, but I have a question. According to the readme in [ha-historical-sensor](https://github.com/ldotlopez/ha-historical-sensor), 'It's recommended to use just "sum" or "mean" statistics, not both, the one which applies to your sensor. Both are shown here just as example.'. However, I see that you've used both for `get_statistic_metadata` method in `HistoricalSensorMixin`. Shouldn't the only `True` one be `has_sum`?